### PR TITLE
Sources, not field

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ You can configure this plugin in your root `_config.yml`.
 ``` yaml
 search:
   path: search.json
+  source: all # other values: posts, pages
 ```

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,34 +3,31 @@
 module.exports = function(locals) {
   var config = this.config;
   var searchConfig = config.search;
-  var searchfield = searchConfig.field;
+  var searchSource = searchConfig.source.trim();
 
-  var posts;
-  var pages;
+  var posts = locals.posts.sort('-date');
+  var pages = locals.pages;
 
-  if (searchfield.trim() != '') {
-    searchfield = searchfield.trim();
-    if (searchfield == 'post') {
-      posts = locals.posts.sort('-date');
-    } else if (searchfield == 'page') {
-      pages = locals.pages;
-    } else {
-      posts = locals.posts.sort('-date');
-      pages = locals.pages;
+  var sources = [];
+
+  if (searchSource != '' && searchSource != 'all') {
+    if (searchSource == 'posts') {
+      sources = posts.data;
+    } else if (searchSource == 'pages') {
+      sources = pages.data;
     }
   } else {
-    posts = locals.posts.sort('-date');
+    sources = posts.data.concat(pages.data);
   }
 
   var data = [];
 
-  posts.forEach(function(post) {
+  sources.forEach(function(post) {
     var item = {
       title: post.title,
       url: config.url+'/'+post.path,
       content: post.content
     };
-
     data.push(item);
   });
 


### PR DESCRIPTION
I feel that current setting `field` does not reflect the context.

- Changing the setting parameter from `field` to `source`
- Rationalizing default value to `all`
- Pluralize sources
- Tidying array build using `concat`