### PR TITLE
hexo-search报错TypeError: Cannot read property 'data' of undefined 解决

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -27,13 +27,18 @@ module.exports = function(locals) {
     var tags = [];
     
     if(post.layout == 'post') {
-      post.categories.data.forEach(function(categorie) {
-        categories.push(categorie.name);
-      });
-      
+ 
+     if(typeof(post.categories)!='undefined'){
+        post.categories.data.forEach(function(categorie) {
+          categories.push(categorie.name);
+        });
+     }
+
+     if(typeof(post.tags)!='undefined'){
       post.tags.data.forEach(function(tag) {
         tags.push(tag.name);
       });
+     }
     }
     
     var item = {


### PR DESCRIPTION
原始错误：$ hexo g
(node:11072) [DEP0061] DeprecationWarning: fs.SyncWriteStream is deprecated.
INFO  Start processing
FATAL Something's wrong. Maybe you can find the solution here: https://hexo.io/docs/troubleshooting.html
TypeError: Cannot read property 'data' of undefined
    at C:\Users\Administrator\Desktop\blog\Fexo_1zeasy_blog\node_modules\hexo-search\lib\generator.js:30:23
    at Array.forEach (<anonymous>)
需要对categories, tags进行判断，否则会报错，无法hexo g 操作。
这是我的第一次github pull request，希望可以同意merge，谢谢！ 
 